### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-website.yaml
+++ b/.github/workflows/docs-website.yaml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Build (Docs)
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/SpechtLabs/StaticPages/security/code-scanning/2](https://github.com/SpechtLabs/StaticPages/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `build` job, explicitly setting `contents: read`. This ensures that the `GITHUB_TOKEN` used in the `build` job has only the minimal permissions required to perform its tasks. The `deploy-gh-pages` and `deploy-static-pages` jobs already have explicit permissions, so no changes are needed for them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
